### PR TITLE
Add new "extensions" property to TokenInfo definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/token-lists",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.18-extensions",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@uniswap/token-lists",
   "author": "Moody Salem",
   "description": "📚 The Token Lists specification",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.18-extensions",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -162,6 +162,18 @@
             "stablecoin",
             "compound"
           ]
+        },
+        "extensions": {
+          "type": "object",
+          "description": "An object containing any arbitrary or vendor-specific token metadata",
+          "additionalProperties": true,
+          "maxProperties": 69,
+          "examples": [
+            {
+              "color": "#000000",
+              "is_verified_by_me": true
+            }
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
This new "extensions" field is meant to contain any vendor-specific token metadata or any other extraneous data which a Token List creator might want to ship with their Token List.

example use cases:
- adding a "color" for each token
- adding a "description" for each token
- adding a "verified" flag on tokens

😘️🦄️🗒️