### PR TITLE
Allow `$` and `:` in symbol and name respectively

### DIFF
--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -128,7 +128,7 @@
           "description": "The name of the token",
           "minLength": 1,
           "maxLength": 40,
-          "pattern": "^[ \\w.'+\\-%/À-ÖØ-öø-ÿ\:]+$",
+          "pattern": "^[ \\w.'+\\-%/À-ÖØ-öø-ÿ\\:]+$",
           "examples": [
             "USD Coin"
           ]
@@ -136,7 +136,7 @@
         "symbol": {
           "type": "string",
           "description": "The symbol for the token; must be alphanumeric",
-          "pattern": "^[a-zA-Z0-9+\\-%/\$]+$",
+          "pattern": "^[a-zA-Z0-9+\\-%/\\$]+$",
           "minLength": 1,
           "maxLength": 20,
           "examples": [

--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -128,7 +128,7 @@
           "description": "The name of the token",
           "minLength": 1,
           "maxLength": 40,
-          "pattern": "^[ \\w.'+\\-%/À-ÖØ-öø-ÿ]+$",
+          "pattern": "^[ \\w.'+\\-%/À-ÖØ-öø-ÿ\:]+$",
           "examples": [
             "USD Coin"
           ]
@@ -136,7 +136,7 @@
         "symbol": {
           "type": "string",
           "description": "The symbol for the token; must be alphanumeric",
-          "pattern": "^[a-zA-Z0-9+\\-%/]+$",
+          "pattern": "^[a-zA-Z0-9+\\-%/\$]+$",
           "minLength": 1,
           "maxLength": 20,
           "examples": [

--- a/test/schema/example-name-symbol-special-characters.tokenlist.json
+++ b/test/schema/example-name-symbol-special-characters.tokenlist.json
@@ -22,6 +22,20 @@
       "symbol": "DIACRITIC",
       "name": "Ázertíyuöp",
       "decimals": 18
+    },
+    {
+      "chainId": 1,
+      "address": "0xEd91879919B71bB6905f23af0A68d231EcF87b14",
+      "symbol": "DMG",
+      "name": "DMM: Governance",
+      "decimals": 18
+    },
+    {
+      "chainId": 1,
+      "address": "0x297D33e17e61C2Ddd812389C2105193f8348188a",
+      "symbol": "$TRDL",
+      "name": "Strudel Finance",
+      "decimals": 18
     }
   ],
   "version": {


### PR DESCRIPTION
This will allow tokens such as `DMM: Governance` and `$TRDL`.