### PR TITLE
Increase ExtensionValue maxLength to 80

### DIFF
--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -78,7 +78,7 @@
         {
           "type": "string",
           "minLength": 1,
-          "maxLength": 42,
+          "maxLength": 80,
           "examples": [
             "#00000"
           ]


### PR DESCRIPTION
We would like to include an id property which is composed of a standard 42 character contract address + a 24 character suffix.

For example: `0x856e4424f806d16e8cbc702b3c0f2ede5468eae5000200000000000000000000`.

I figure 66 characters is sort of a weird limit, so I chose 80 chars for more flexibility.