### PR TITLE
Include colon in TagDefinition regex pattern

### DIFF
--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -115,7 +115,7 @@
         "description": {
           "type": "string",
           "description": "A user-friendly description of the tag",
-          "pattern": "^[ \\w\\.,]+$",
+          "pattern": "^[ \\w\\.,:]+$",
           "minLength": 1,
           "maxLength": 200
         }


### PR DESCRIPTION
This PR adds the `:` (colon) character to tag descriptions since we would like to use abbreviations like `ie:` or `eg:` in our descriptions.

