### PR TITLE
add `.` to symbol pattern

### DIFF
--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -175,7 +175,7 @@
         "symbol": {
           "type": "string",
           "description": "The symbol for the token; must be alphanumeric",
-          "pattern": "^[a-zA-Z0-9+\\-%\\/\\$]+$",
+          "pattern": "^[a-zA-Z0-9+\\-%\\/\\$.]+$",
           "minLength": 1,
           "maxLength": 20,
           "examples": [


### PR DESCRIPTION
Allows for assets such as `LINK.e`