### PR TITLE
increase length limit for token list name

### DIFF
--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -288,7 +288,7 @@
       "type": "string",
       "description": "The name of the token list",
       "minLength": 1,
-      "maxLength": 20,
+      "maxLength": 30,
       "pattern": "^[\\w ]+$",
       "examples": [
         "My Token List"


### PR DESCRIPTION
Increasing length limit of token list names from 20 to 30 to allow for longer names. We are not completely removing the limit in order to prevent spoofing, such as right-padding with whitespace. 