### PR TITLE
update TokenInfo extensions type to support objects nested 2 levels deep

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-type ExtensionValue = string | number | boolean | null;
+type ExtensionValue = string | number | boolean | null | undefined;
 
 export interface TokenInfo {
   readonly chainId: number;
@@ -9,7 +9,15 @@ export interface TokenInfo {
   readonly logoURI?: string;
   readonly tags?: string[];
   readonly extensions?: {
-    readonly [key: string]: { [key: string]: ExtensionValue } | ExtensionValue;
+    readonly [key: string]:
+      | {
+          [key: string]:
+            | {
+                [key: string]: ExtensionValue;
+              }
+            | ExtensionValue;
+        }
+      | ExtensionValue;
   };
 }
 


### PR DESCRIPTION
There is an inconsistency between the tokenlist [schema](https://github.com/Uniswap/token-lists/blob/main/src/tokenlist.schema.json) and the TokenInfo [interface](https://github.com/Uniswap/token-lists/blob/main/src/types.ts#L11-L13). The schema supports objects nested 2 levels deep (as it should), however the interface does not. This PR updates the TokenInfo extensions type/interface to also support 2-level nested objects. 

This change was tested by importing a token list JSON file with the nested objects (cross-chain list) and verifying that there are no errors when setting it as a [TokenList](https://github.com/Uniswap/token-lists/blob/main/src/types.ts#L29-L37) type.