### PR TITLE
feat: add tokenMap to schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://uniswap.org"
   },
   "description": "📚 The Token Lists specification",
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -328,6 +328,14 @@
     "tokenMap": {
       "type": "object",
       "description": "A mapping of key 'chainId_tokenAddress' to its corresponding token object",
+      "minProperties": 1,
+      "maxProperties": 10000,
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/TokenInfo"
+      },
       "examples": [
         {
           "4_0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984":  {

--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -325,6 +325,22 @@
       "minItems": 1,
       "maxItems": 10000
     },
+    "tokenMap": {
+      "type": "object",
+      "description": "A mapping of key 'chainId_tokenAddress' to its corresponding token object",
+      "examples": [
+        {
+          "4_0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984":  {
+            "name": "Uniswap",
+            "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+            "symbol": "UNI",
+            "decimals": 18,
+            "chainId": 4,
+            "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+          }
+        }
+      ]
+    },
     "keywords": {
       "type": "array",
       "description": "Keywords associated with the contents of the list; may be used in list discoverability",


### PR DESCRIPTION
Add tokenMap to schema so we can add a map in default-token-list, and the other token list repos. Useful to avoid re-declaring token constants in downstream repos (like smart order router, interface). 