### PR TITLE
fix: update types to include tokenMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://uniswap.org"
   },
   "description": "📚 The Token Lists specification",
-  "version": "1.0.0-beta.32",
+  "version": "1.0.0-beta.33",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,9 @@ export interface TokenList {
   readonly timestamp: string;
   readonly version: Version;
   readonly tokens: TokenInfo[];
+  readonly tokenMap?: {
+    readonly [key: string]: TokenInfo;
+  };
   readonly keywords?: string[];
   readonly tags?: Tags;
   readonly logoURI?: string;

--- a/test/schema/example.tokenlist.json
+++ b/test/schema/example.tokenlist.json
@@ -41,6 +41,30 @@
       ]
     }
   ],
+  "tokenMap": {
+    "1_0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
+      "chainId": 1,
+      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "symbol": "USDC",
+      "name": "USD Coin",
+      "decimals": 6,
+      "logoURI": "ipfs://QmXfzKRvjZz3u5JRgC4v5mGVbm9ahrUiB4DgzHBsnWbTMM",
+      "tags": [
+        "stablecoin"
+      ]
+    },
+    "1_0x39AA39c021dfbaE8faC545936693aC917d5E7563":  {
+      "chainId": 1,
+      "address": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
+      "symbol": "cUSDC",
+      "name": "Compound USD Coin",
+      "decimals": 8,
+      "logoURI": "ipfs://QmUSNbwUxUYNMvMksKypkgWs8unSm8dX2GjCPBVGZ7GGMr",
+      "tags": [
+        "compound"
+      ]
+    }
+  }, 
   "version": {
     "major": 1,
     "minor": 0,


### PR DESCRIPTION
This should've been done in https://github.com/Uniswap/token-lists/pull/420 , but overlooked this and updating the schemas in this PR. 