### PR TITLE
feat: major version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://uniswap.org"
   },
   "description": "📚 The Token Lists specification",
-  "version": "1.0.0-beta.33",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Addition of tokenMap to schema can potentially cause breaking changes in downstream repos doing validation. Doing a major version bump to account for this. 