### PR TITLE
fix: allow additional top level fields

### DIFF
--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -296,7 +296,6 @@
     }
   },
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "name": {
       "type": "string",

--- a/test/__snapshots__/tokenlist.schema.test.ts.snap
+++ b/test/__snapshots__/tokenlist.schema.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`schema allows additional top-level fields 1`] = `null`;
+
 exports[`schema allows up to 10k tokens 1`] = `null`;
 
 exports[`schema checks extensions 1`] = `null`;

--- a/test/tokenlist.schema.test.ts
+++ b/test/tokenlist.schema.test.ts
@@ -136,4 +136,12 @@ describe('schema', () => {
     };
     checkSchema(exampleListWith10kTokensPlusOne, false);
   });
+
+  it('allows additional top-level fields', () => {
+    const exampleListWithUnknownField = {
+      ...exampleList,
+      unknownField: 'foo',
+    };
+    checkSchema(exampleListWithUnknownField, true);
+  });
 });


### PR DESCRIPTION
https://linear.app/uniswap/issue/WEB-2539/update-the-token-list-schema-validator-to-allow-unexpected-fields