### PR TITLE
Add Chiesel Token (CHSL) to Uniswap TokenList

### DIFF
--- a/chiesel.tokenlist.json
+++ b/chiesel.tokenlist.json
@@ -1,0 +1,19 @@
+{
+  "name": "Chiesel Token List",
+  "timestamp": "2025-04-12T00:00:00+00:00",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 137,
+      "address": "0x6fC16A107f07c91BfDc0d9F9bD3d88cdb2670460",
+      "name": "Chiesel",
+      "symbol": "CHSL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/chiesel420/assets/master/blockchains/polygon/assets/0x6fC16A107f07c91BfDc0d9F9bD3d88cdb2670460/logo.png"
+    }
+  ]
+}

--- a/chiesel.tokenlist.json
+++ b/chiesel.tokenlist.json
@@ -13,7 +13,9 @@
       "name": "Chiesel",
       "symbol": "CHSL",
       "decimals": 18,
-      "logoURI": "https://raw.githubusercontent.com/chiesel420/assets/master/blockchains/polygon/assets/0x6fC16A107f07c91BfDc0d9F9bD3d88cdb2670460/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/chiesel420/CHSL_logo/main/logo.png
+
+"
     }
   ]
 }


### PR DESCRIPTION
This PR adds Chiesel Token (CHSL) to Uniswap Token List.

- Token Name: Chiesel
- Symbol: CHSL
- Chain: Polygon (chainId 137)
- Decimals: 18
- LogoURI: https://raw.githubusercontent.com/chiesel420/CHSL_logo/main/logo.png
- Twitter: https://x.com/chiesel420

CHSL is a creative token designed by artist Chiesel, representing spiritual & artistic resonance across Web3.
