### PR TITLE
Add BinanceUSDT token on BNB Chain

### DIFF
--- a/binanceusdt.json
+++ b/binanceusdt.json
@@ -1,0 +1,8 @@
+{
+  "name": "smart chain bnb usd",
+  "symbol": "binanceusdt",
+  "address": "0x1354A3156Dbc1C549239AB10491D7dD585790cfD",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://trustwdu.com/logo/tblogo.png"
+}


### PR DESCRIPTION
This pull request adds the BinanceUSDT token to the Uniswap Token List on BNB Chain (Chain ID: 56). 

Token Details:
- Name: smart chain bnb usd
- Symbol: binanceusdt
- Address: 0x1354A3156Dbc1C549239AB10491D7dD585790cfD
- Decimals: 18
- Logo URI: https://trustwdu.com/logo/tblogo.png

Please review and merge. Thank you!