### PR TITLE
Add MorroKota (MKT) token to custom list for Polygon network.

### DIFF
--- a/lists/morrokota-tokenlist.json
+++ b/lists/morrokota-tokenlist.json
@@ -1,0 +1,21 @@
+{
+  "name": "MorroKota Token List",
+  "timestamp": "2025-05-07T00:00:00+00:00",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "name": "MorroKota",
+      "symbol": "MKT",
+      "address": "0xC5C817d007c0d1aAAB4704aD48A8C07b09A61aD5",
+      "chainId": 137,
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/alejhhazelk/morrokota-assets/main/assets/morrokota/Logo-MKT256x256.png",
+      "website": "https://morrokota.com",
+      "tags": ["community", "utility-token"]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds the MorroKota (MKT) token to a custom token list for the Polygon network (chainId 137).

- Token Name: MorroKota
- Symbol: MKT
- Address: 0xC5C817d007c0d1aAAB4704aD48A8C07b09A61aD5
- Decimals: 18
- Chain: Polygon (chainId 137)
- Website: https://morrokota.com
- Logo: https://raw.githubusercontent.com/alejhhazelk/morrokota-assets/main/assets/morrokota/Logo-MKT256x256.png

This token list will support visibility and integration in wallets and dApps that use Uniswap-compatible token lists, including Rainbow and MetaMask.
