### PR TITLE
Add Imperimi USDi Token List

### DIFF
--- a/lists/imperimi-usdi.json
+++ b/lists/imperimi-usdi.json
@@ -1,0 +1,19 @@
+{
+  "name": "Imperimi Token List",
+  "timestamp": "2024-05-02T00:00:00Z",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 8453,
+      "address": "0xc4Be3d8Ce8ed547eDc75C32300B6b0A0f8648A89",
+      "name": "USDi by Imperimi",
+      "symbol": "USDi",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/Imperimi/usdi-tokenlist/main/usdi.png"
+    }
+  ]
+}


### PR DESCRIPTION
Official token list for USDi by Imperimi on Base chain.

- Token: 0xc4Be3d8Ce8ed547eDc75C32300B6b0A0f8648A89  
- Website: https://imperimi.com  
- Tokenlist: https://raw.githubusercontent.com/Imperimi/token-lists/main/lists/imperimi-usdi.json  
- Logo included  
- Maintained by: Imperimi team
