### PR TITLE
Add Assemble AI Token List

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -1,9 +1,25 @@
-[
-  {
-    "name": "Assemble AI Token List",
-    "logoURI": "https://s3.coinmarketcap.com/static-gravity/image/d34420ceb6fb4faeb67c60dc3e35e593.png",
-    "tokens": 2,
-    "timestamp": "2025-06-16T15:00:00Z",
-    "url": "https://raw.githubusercontent.com/AssembleAI-crypto/assemble-tokenlist/main/tokenlist.json"
-  }
-]
+{
+  "name": "Assemble AI Token List",
+  "logoURI": "https://raw.githubusercontent.com/AssembleAI-crypto/assemble-tokenlist/main/logo.png",
+  "keywords": ["ASM", "AssembleAI", "Assemble AI", "Assemble protocol", "AssembleProtocol"],
+  "timestamp": "2025-06-16T15:00:00Z",
+  "version": { "major": 1, "minor": 0, "patch": 0 },
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0x2565ae0385659badcada1031db704442e1b69982",
+      "name": "ASSEMBLE",
+      "symbol": "ASM",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/AssembleAI-crypto/assemble-tokenlist/main/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3b53604113B5677291BFc0bc255379E7a796559b",
+      "name": "ASSEMBLE",
+      "symbol": "ASM",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/AssembleAI-crypto/assemble-tokenlist/main/logo.png"
+    }
+  ]
+}

--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Assemble AI Token List",
+    "logoURI": "https://s3.coinmarketcap.com/static-gravity/image/d34420ceb6fb4faeb67c60dc3e35e593.png",
+    "tokens": 2,
+    "timestamp": "2025-06-16T15:00:00Z",
+    "url": "https://raw.githubusercontent.com/AssembleAI-crypto/assemble-tokenlist/main/tokenlist.json"
+  }
+]


### PR DESCRIPTION
This PR adds the official Assemble AI Token List to the community registry.

- Includes tokens deployed on Ethereum and Base
- Follows TokenLists.org JSON schema

Token list URL:
https://raw.githubusercontent.com/AssembleAI-crypto/assemble-tokenlist/main/tokenlist.json

CMC URL:
https://coinmarketcap.com/currencies/assemble-protocol/

Thank you for your review and consideration.