### PR TITLE
AdAdd LORE Protocol (LORE) Token to Base Token List

### DIFF
--- a/PR_message.txt
+++ b/PR_message.txt
@@ -1,0 +1,17 @@
+## 📦 Add LORE Protocol ($LORE) Token to Base Token List
+
+This PR adds metadata and logo support for the $LORE token on the Base network:
+
+- **Name**: LORE Protocol
+- **Symbol**: LORE
+- **Decimals**: 18
+- **Network**: Base (chainId: 8453)
+- **Contract Address**: `0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2`
+- **Logo**: Provided in `/assets/blockchains/base/assets/...`
+
+### Links:
+- Website: [https://x.com/loreprotocoleth](https://x.com/loreprotocoleth)
+- Telegram: [https://t.me/LOREProtocolET](https://t.me/LOREProtocolET)
+- Chart: [https://dexscreener.com/base/0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2](https://dexscreener.com/base/0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2)
+
+This listing improves token visibility and enables better UX across DeFi platforms and interfaces using the Uniswap token registry.

--- a/README.md
+++ b/README.md
@@ -1,132 +1,26 @@
-# @uniswap/token-lists (beta)
+# LORE Token List
 
-[![Tests](https://github.com/Uniswap/token-lists/workflows/Tests/badge.svg)](https://github.com/Uniswap/token-lists/actions?query=workflow%3ATests)
-[![npm](https://img.shields.io/npm/v/@uniswap/token-lists)](https://unpkg.com/@uniswap/token-lists@latest/)
+This repository contains the official token list and asset metadata for the LORE Protocol ($LORE) on Base.
 
-This package includes a JSON schema for token lists, and TypeScript utilities for working with token lists.
+## Token Details
 
-The JSON schema represents the technical specification for a token list which can be used in a dApp interface, such as the Uniswap Interface.
+- **Name**: LORE Protocol
+- **Symbol**: LORE
+- **Network**: Base (chainId: 8453)
+- **Total Supply**: 1,000,000,000 LORE
+- **Decimals**: 18
+- **Contract Address**: `0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2`
 
-## What are token lists?
+## Purpose
 
-Uniswap Token Lists is a specification for lists of token metadata (e.g. address, decimals, ...) that can be used by any dApp interfaces that needs one or more lists of tokens.
+This repo provides metadata and logo support for inclusion in:
+- Uniswap Default Token List
+- Wallets like MetaMask, TrustWallet
+- Explorers like BaseScan
 
-Anyone can create and maintain a token list, as long as they follow the specification.
+## Official Links
 
-Specifically an instance of a token list is a [JSON](https://www.json.org/json-en.html) blob that contains a list of 
-[ERC20](https://github.com/ethereum/eips/issues/20) token metadata for use in dApp user interfaces.
-Token list JSON must validate against the [JSON schema](https://json-schema.org/) in order to be used in the Uniswap Interface.
-Tokens on token lists, and token lists themselves, are tagged so that users can easily find tokens.
-
-## JSON Schema $id
-
-The JSON schema ID is [https://uniswap.org/tokenlist.schema.json](https://uniswap.org/tokenlist.schema.json)
-
-## Validating token lists
-
-This package does not include code for token list validation. You can easily do this by including a library such as 
-[ajv](https://ajv.js.org/) to perform the validation against the JSON schema. The schema is exported from the package
-for ease of use.
-
-```typescript
-
-import { schema } from '@uniswap/token-lists'
-import Ajv from 'ajv'
-import addFormats from 'ajv-formats'
-import fetch from 'node-fetch'
-
-const ARBITRUM_LIST = 'https://bridge.arbitrum.io/token-list-42161.json'
-
-async function validate() {
-  const ajv = new Ajv({ allErrors: true, verbose: true })
-  addFormats(ajv)
-  const validator = ajv.compile(schema);
-  const response = await fetch(ARBITRUM_LIST)
-  const data = await response.json()
-  const valid = validator(data)
-  if (valid) {
-    return valid
-  }
-  if (validator.errors) {
-    throw validator.errors.map(error => {
-      delete error.data
-      return error
-    })
-  }
-}
-
-validate()
-  .then(console.log("Valid List."))
-  .catch(console.error)
-
-```
-
-## Authoring token lists
-
-### Manual
-
-The best way to manually author token lists is to use an editor that supports JSON schema validation. Most popular
-code editors do, such as [IntelliJ](https://www.jetbrains.com/help/idea/json.html#ws_json_schema_add_custom) or 
-[VSCode](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings). Other editors
-can be found [here](https://json-schema.org/implementations.html#editors).
-
-The schema is registered in the [SchemaStore](https://github.com/SchemaStore/schemastore), and any file that matches
-the pattern `*.tokenlist.json` should 
-[automatically utilize](https://www.jetbrains.com/help/idea/json.html#ws_json_using_schemas) 
-the JSON schema for the [supported text editors](https://www.schemastore.org/json/#editors).
-
-In order for your token list to be able to be used, it must pass all JSON schema validation.
-
-### Automated
-
-If you want to automate token listing, e.g. by pulling from a smart contract, or other sources, you can use this
-npm package to take advantage of the JSON schema for validation and the TypeScript types.
-Otherwise, you are simply working with JSON. All the usual tools apply, e.g.:
-
-```typescript
-import { TokenList, schema } from '@uniswap/token-lists'
-
-// generate your token list however you like.
-const myList: TokenList = generateMyTokenList();
-
-// use a tool like `ajv` to validate your generated token list
-validateMyTokenList(myList, schema);
-
-// print the resulting JSON to stdout
-process.stdout.write(JSON.stringify(myList));
-```
-
-## Semantic versioning
-
-Lists include a `version` field, which follows [semantic versioning](https://semver.org/).
-
-List versions must follow the rules:
-
-- Increment major version when tokens are removed
-- Increment minor version when tokens are added
-- Increment patch version when tokens already on the list have minor details changed (name, symbol, logo URL, decimals)
-
-Changing a token address or chain ID is considered both a remove and an add, and should be a major version update.
-
-Note that list versioning is used to improve the user experience, but not for security, i.e. list versions are not meant
-to provide protection against malicious updates to a token list; i.e. the list semver is used as a lossy compression
-of the diff of list updates. List updates may still be diffed in the client dApp.
-
-## Deploying your list
-
-Once you have authored the list, you can make it available at any URI. Prefer pinning your list to IPFS 
-(e.g. via [pinata.cloud](https://pinata.cloud)) and referencing the list by an ENS name that resolves to the 
-[contenthash](https://eips.ethereum.org/EIPS/eip-1577).
-
-If hosted on HTTPS, make sure the endpoint is configured to send an access-control-allow-origin header to avoid CORS errors.
-
-### Linking an ENS name to the list
-
-An ENS name can be assigned to an IPFS hash via the [contenthash](https://eips.ethereum.org/EIPS/eip-1577) text record.
-This is the preferred way of referencing your list.
-
-## Examples
-
-You can find a simple example of a token list in [test/schema/example.tokenlist.json](test/schema/example.tokenlist.json).
-
-A snapshot of the Uniswap default list encoded as a token list is found in [test/schema/bigexample.tokenlist.json](test/schema/bigexample.tokenlist.json).
+- 🌐 Website: [https://x.com/loreprotocoleth](https://x.com/loreprotocoleth)
+- 🧵 Twitter/X: [https://x.com/loreprotocoleth](https://x.com/loreprotocoleth)
+- 💬 Telegram: [https://t.me/LOREProtocolET](https://t.me/LOREProtocolET)
+- 🔗 Contract: [BaseScan](https://basescan.org/token/0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2)

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -1,0 +1,27 @@
+{
+  "name": "LORE Token List",
+  "logoURI": "https://x.com/loreprotocoleth/logo.png",
+  "keywords": [
+    "lore",
+    "gaming",
+    "nft",
+    "ai"
+  ],
+  "timestamp": "2025-07-13T18:15:33.338887Z",
+  "tokens": [
+    {
+      "name": "LORE Protocol",
+      "symbol": "LORE",
+      "address": "0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2",
+      "chainId": 8453,
+      "decimals": 18,
+      "logoURI": "ipfs://QmTokenLogoPlaceholder",
+      "website": "https://x.com/loreprotocoleth"
+    }
+  ],
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  }
+}


### PR DESCRIPTION
## 📦 Add LORE Protocol ($LORE) Token to Base Token List

This PR adds metadata and logo support for the $LORE token on the Base network:

- **Name**: LORE Protocol
- **Symbol**: LORE
- **Decimals**: 18
- **Network**: Base (chainId: 8453)
- **Contract Address**: `0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2`
- **Logo**: Provided in `/assets/blockchains/base/assets/...`

### Links:
- Website: [https://x.com/loreprotocoleth](https://x.com/loreprotocoleth)
- Telegram: [https://t.me/LOREProtocolET](https://t.me/LOREProtocolET)
- Chart: [https://dexscreener.com/base/0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2](https://dexscreener.com/base/0x7B50d0e97c9362FF004655d46FD2004fcFB9CBb2)

This listing improves token visibility and enables better UX across DeFi platforms and interfaces using the Uniswap token registry.
