### PR TITLE
Add SkibidiPoppy (SKP) Token List

### DIFF
--- a/src/tokens/skibDpoP/tokenlist.json
+++ b/src/tokens/skibDpoP/tokenlist.json
@@ -1,0 +1,16 @@
+{
+  "name": "SKP Token List",
+  "logoURI": "https://skibDpoP.github.io/skp-tokenlist/skp-logo-256x256.png",
+  "keywords": ["skp", "skibidipoppy"],
+  "timestamp": "2025-07-18T16:00:00Z",
+  "tokens": [
+    {
+      "chainId": 10,
+      "address": "0x8072CF35fA415DF296F0038f8d8163f81f6d44AD",
+      "symbol": "SKP",
+      "name": "SkibidiPoppy",
+      "decimals": 18,
+      "logoURI": "https://skibDpoP.github.io/skp-tokenlist/skp-logo-256x256.png"
+    }
+  ]
+}


### PR DESCRIPTION
his pull request adds the SkibidiPoppy (SKP) token list to the Uniswap token lists.

✅ Token Details:
- Name: SkibidiPoppy
- Symbol: SKP
- Chain ID: 10 (Optimism)
- Address: 0x8072CF35fA415DF296F0038f8d8163f81f6d44AD
- Decimals: 18
- Logo hosted on GitHub Pages

🔗 Token List URL:
https://raw.githubusercontent.com/skibDpoP/skp-tokenlist/main/tokenlist.json

📝 Notes:
- The list follows the Uniswap token list schema.
- Token logo is 256x256 and correctly linked.