### PR TITLE
chore: add arcx-list.json for token configuration

### DIFF
--- a/data/artifact/arcx-list.json
+++ b/data/artifact/arcx-list.json
@@ -1,0 +1,21 @@
+{
+  "name": "Artifact Token List",
+  "logoURI": "https://raw.githubusercontent.com/Artifact-Virtual/arcx_token/main/logo/av-white-logo-removebg-preview.png",
+  "timestamp": "2025-07-29T00:00:00+00:00",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 8453,
+      "address": "0xDa1d3752a2227FA2d2ad86Ba1D637d1d33D585ec",
+      "name": "ARCx",
+      "symbol": "ARCx",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/Artifact-Virtual/arcx_token/main/logo/av-white-logo-removebg-preview.png",
+      "tags": ["funding", "constitutional", "erc20"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the ARCx token to a new curated list under artifact/arcx-list.json. ARCx is a fixed-supply, time-bound ERC20 token designed to bootstrap The Arc Protocol and enable one-way migration to FUEL. This is the genesis token of the Artifact Virtual ecosystem.

Token List Name: Artifact Token List
List URL: arcx-list.json
🧬 Token Details

    Token Name: ARCx

    Symbol: ARCx

    Chain ID: 8453 (Base Mainnet)

    Address: [0xDa1d3752a2227FA2d2ad86Ba1D637d1d33D585ec](https://basescan.org/address/0xDa1d3752a2227FA2d2ad86Ba1D637d1d33D585ec)

    Decimals: 18

    Verified on: BaseScan & Sourcify

   
🔐 Audit & Documentation

    Audit: [security-report.md](https://github.com/Artifact-Virtual/arcx_token/blob/main/audits/security-report.md)

    Whitepaper: [whitepaper.md](https://github.com/Artifact-Virtual/arcx_token/blob/main/docs/WHITEPAPER.md)

    Repo: [Artifact-Virtual/arcx_token](https://github.com/Artifact-Virtual/arcx_token)

📌 Notes

    ARCx is deployed on Base Mainnet and serves as the genesis provisioning asset for The Arc and ADAM Protocols.

    This list is curated and maintained by Artifact Virtual and will include FUEL and additional ecosystem tokens in future iterations.