### PR TITLE
Add Chrono Rift Token List to registry

### DIFF
--- a/lists.json
+++ b/lists.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "Chrono Rift Token List",
+    "url": "https://chronorift.org/chrono-rift-tokenlist.json"
+  }
+]


### PR DESCRIPTION
This pull request adds the official Chrono Rift Token List to the Uniswap token lists registry.

Token Name: Chrono Rift (CRFT)
Network: Ethereum Mainnet (chainId 1)
Token Address: 0xbda3d279102b8937b2fc9861ff0cd44d67aafda2
Logo: [https://chronorift.org/chrono-rift-token-logo.png](vscode-file://vscode-app/c:/Users/Bruger/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Website: [https://chronorift.org](vscode-file://vscode-app/c:/Users/Bruger/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Token List URL: [https://chronorift.org/chrono-rift-tokenlist.json](vscode-file://vscode-app/c:/Users/Bruger/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Description: Chrono Rift (CRFT) is a community-driven ERC-20 token powering time-based digital experiences, gamified finance, and decentralized governance.
This update ensures Chrono Rift is discoverable and usable across Uniswap interfaces and other platforms supporting token lists.