### PR TITLE
chore: increase `extension` value to 200

### DIFF
--- a/src/tokenlist.schema.json
+++ b/src/tokenlist.schema.json
@@ -103,7 +103,7 @@
         {
           "type": "string",
           "minLength": 1,
-          "maxLength": 42,
+          "maxLength": 200,
           "examples": [
             "#00000"
           ]


### PR DESCRIPTION
In my tokenlist I have `inlined` as a field that URL encodes the `logoURI`. If there are no issues with increasing the max length I hope you approve and merge this.