### PR TITLE
Add liquidao token (Base network)

### DIFF
--- a/liquidao-base.tokenlist.json
+++ b/liquidao-base.tokenlist.json
@@ -1,0 +1,32 @@
+{
+  "name": "Liquidao Token List",
+  "logoURI": "https://www.liquidao.io/logo/liquidao-logo-colour.png",
+  "keywords": ["defi", "yield", "liquidao", "base"],
+  "tags": {
+    "defi": {
+      "name": "DeFi",
+      "description": "Decentralized finance tokens"
+    },
+    "yield": {
+      "name": "Yield Farming",
+      "description": "Tokens related to farming and liquidity pools"
+    }
+  },
+  "timestamp": "2025-09-23T00:00:00+00:00",
+  "tokens": [
+    {
+      "chainId": 8453,
+      "address": "0xeb25717632A1682e7Cd9Cd9B03fB08Bf367Ccf95",
+      "name": "Liquidao",
+      "symbol": "LIQ",
+      "decimals": 18,
+      "logoURI": "https://www.liquidao.io/logo/liquidao-logo-colour.png",
+      "tags": ["defi", "yield"]
+    }
+  ],
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  }
+}


### PR DESCRIPTION
This PR adds the Liquidao token to the Uniswap token list.

Chain: Base (chainId 8453)
Token: LIQ
Contract: 0xeb25717632A1682e7Cd9Cd9B03fB08Bf367Ccf95
Logo: https://www.liquidao.io/logo/liquidao-logo-colour.png