### PR TITLE
Add SO-NET-CO to Uniswap token list  

### DIFF
--- a/lists/sonetco-bsc.json
+++ b/lists/sonetco-bsc.json
@@ -1,0 +1,18 @@
+{
+  "name": "Social Network Coin List",
+  "timestamp": "2025-09-24T00:00:00+00:00",
+  "version": { "major": 1, "minor": 0, "patch": 0 },
+  "logoURI": "https://raw.githubusercontent.com/sonetco/socialnetworkcoin/main/blockchainsbinanceassets0x5dbc4d59ac92845790482ae1cfabf5efdf7ca2e7logo.png.png",
+  "keywords": ["social", "defi"],
+  "tokens": [
+    {
+      "chainId": 56,
+      "address": "0x5dbc4d59ac92845790482ae1cfabf5efdf7ca2e7",
+      "name": "Social Network Coin",
+      "symbol": "SO-NET-CO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/sonetco/socialnetworkcoin/main/blockchainsbinanceassets0x5dbc4d59ac92845790482ae1cfabf5efdf7ca2e7logo.png.png",
+      "tags": ["social","rewards"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds SOcial NETwork COin (SO-NET-CO) to the official Uniswap token list.

"Adds token SO-NET-CO to the Uniswap list"

"Expands the token list with our SOcial NETwork COin"