### PR TITLE
Add HONEY BADGER (HNYBG) Token List for Base Chain

### DIFF
--- a/src/hnybg.json
+++ b/src/hnybg.json
@@ -1,0 +1,22 @@
+{
+  "name": "HONEY BADGER Official List",
+  "logoURI": "https://hnybg.io/logo-256.png",
+  "timestamp": "2025-10-08T00:00:00Z",
+  "version": { "major": 0, "minor": 1, "patch": 0 },
+  "keywords": ["hnybg", "honeybadger", "base", "token"],
+  "tokens": [
+    {
+      "chainId": 8453,
+      "address": "0x6EdA5E0EDCc40bC8F492eeF7f270880Ea9362dB6",
+      "name": "HONEY BADGER",
+      "symbol": "HNYBG",
+      "decimals": 18,
+      "logoURI": "https://hnybg.io/logo-256.png",
+      "extensions": {
+        "website": "https://hnybg.io",
+        "twitter": "https://x.com/XHNYBG",
+        "description": "The official token of Honey Badger on Base chain."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adding the official **HONEY BADGER (HNYBG)** token list for Base network.

- **Website:** https://hnybg.io  
- **Contract (Base):** 0x6EdA5E0EDCc40bC8F492eeF7f270880Ea9362dB6  
- **Token List URL:** https://hnybg.io/tokenlist.json  
- **Logo:** https://hnybg.io/logo-256.png  
- **Chain ID:** 8453 (Base)

The list follows the official Uniswap Token List JSON schema (EIP-3011).
