### PR TITLE
Add RINGS (RIG) token to Base network list

### DIFF
--- a/test/schema/example.tokenlist.json
+++ b/test/schema/example.tokenlist.json
@@ -1,4 +1,16 @@
 {
+  "chainId": 8453,
+  "address": "0xE6277F42E8fb3A03133A7A27C8e5B59858B6d9bA",
+  "name": "RINGS",
+  "symbol": "RIG",
+  "decimals": 18,
+  "logoURI": "https://rings33.pages.dev/logo-ringstoken.png",
+  "tags": [
+    "erc20"
+  ]
+}
+
+{
   "name": "My Token List",
   "logoURI": "ipfs://QmUSNbwUxUYNMvMksKypkgWs8unSm8dX2GjCPBVGZ7GGMr",
   "keywords": [


### PR DESCRIPTION
Hello Uniswap Team,

I am requesting the addition of the RINGS (RIG) token to the Base network list.

- Token Name: RINGS
- Symbol: RIG
- Contract (Base): 0xE6277F42E8fb3A03133A7A27C8e5B59858B6d9bA
- Logo URI: https://rings33.pages.dev/logo-ringstoken.png

The contract is verified on Basescan and features a yield/bonus mechanism based on a precise DateTime library for January 1st and July 1st claims.

Thank you!